### PR TITLE
MWPW-192736: Add check for milolibs query param

### DIFF
--- a/adobe-students/scripts/utils.js
+++ b/adobe-students/scripts/utils.js
@@ -15,6 +15,7 @@ export const [setLibs, getLibs] = (() => {
         return libs;
       }
       const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
+      if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
       if (branch === 'local') { libs = 'http://localhost:6456/libs'; return libs; }
       if (branch.indexOf('--') > -1) { libs = `https://${branch}.hlx.live/libs`; return libs; }
       libs = `https://${branch}--milo--adobecom.hlx.live/libs`;


### PR DESCRIPTION
Whitelist branch parameter with `/^[a-zA-Z0-9_-]+$/`; throw on any other characters.

## Ticket
https://jira.corp.adobe.com/browse/MWPW-192736

## Test URLs
Before: https://main--adobe-students--adobecom.aem.page/
After: https://MWPW-192736--adobe-students--zagi25.aem.page/

---
_This PR was generated by Claude (Anthropic's Claude Code CLI)._